### PR TITLE
Remove unnecessary date variable

### DIFF
--- a/src/main/scala/fabricator/entities/RandomDate.scala
+++ b/src/main/scala/fabricator/entities/RandomDate.scala
@@ -16,8 +16,6 @@ class RandomDate(private val cal: Calendar) {
 
   private var minute: Int = cal.minute.toInt
 
-  private var date: DateTime = new DateTime(year, month, day, hour, minute)
-
   def inYear(year: Int): this.type = {
     this.year = year
     this.day = cal.day(year, this.month).toInt
@@ -70,8 +68,7 @@ class RandomDate(private val cal: Calendar) {
   }
 
   private def makeDate: DateTime = {
-    date = new DateTime(year, month, day, hour, minute)
-    date
+    new DateTime(year, month, day, hour, minute)
   }
 
   def asDate: DateTime = {


### PR DESCRIPTION
Remove unnecessary date variable which also sometimes caused problems with 
`Exception in thread "main" org.joda.time.IllegalInstantException: Illegal instant due to time zone offset transition (daylight savings time 'gap'): 1983-03-27T02:07:00.000 (Europe/Prague)` because it was initialized with random values from https://github.com/D0d0/fabricator/blob/master/src/main/scala/fabricator/entities/RandomDate.scala#L17