### PR TITLE
Update Guice to 4.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ libraryDependencies ++= Seq(
   "com.spatial4j" % "spatial4j" % "0.4.1",
   "org.iban4j" % "iban4j" % "2.1.1",
   "commons-validator" % "commons-validator" % "1.4.0",
-  "com.google.inject" % "guice" % "3.0",
+  "com.google.inject" % "guice" % "4.1.0",
   "com.github.tototoshi" %% "scala-csv" % "1.3.4",
   "com.google.zxing" % "core" % "3.2.0",
   "io.github.lukehutch" % "fast-classpath-scanner" % "2.0.17"


### PR DESCRIPTION
Seems like it works without any changes - most projects have moved. 

This fixes a warning in my usage of the library:

```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible: 
[warn]
[warn]  * com.google.inject:guice:4.1.0 is selected over 3.0
[warn]      +- com.typesafe.play:play-guice_2.11:2.6.3            (depends on 4.1.0)
[warn]      +- com.google.inject.extensions:guice-assistedinject:4.1.0 (depends on 4.1.0)
[warn]      +- com.github.azakordonets:fabricator_2.11:2.1.5      (depends on 3.0)
```


