### PR TITLE
Fix build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
 - openjdk8
 - openjdk7
 scala:
-  - 2.11.8
-  - 2.12.2
+  - 2.11.12
+  - 2.12.10
 script:
 - sbt clean coverage test
 - sbt coverageReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 jdk:
-- oraclejdk8
-- oraclejdk7
+- openjdk8
+- openjdk7
 script:
 - sbt clean coverage test
 - sbt coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 dist: trusty
+
 language: scala
+
 jdk:
-- openjdk8
-- openjdk7
+  - openjdk8
+  - openjdk7
+
 scala:
   - 2.11.12
   - 2.12.10
+
 script:
-- sbt clean coverage test
-- sbt coverageReport coveralls
+  - sbt clean coverage test
+  - sbt coverageReport coveralls
 
 before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: scala
 jdk:
 - openjdk8
 - openjdk7
+scala:
+  - 2.11.8
+  - 2.12.2
 script:
 - sbt clean coverage test
 - sbt coverageReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,13 @@ jdk:
 script:
 - sbt clean coverage test
 - sbt coveralls
+
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 jdk:
 - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 - openjdk7
 script:
 - sbt clean coverage test
-- sbt coveralls
+- sbt coverageReport coveralls
 
 before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import sbt.Keys._
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.8", "2.12.2")
+crossScalaVersions := Seq("2.11.12", "2.12.10")
 
 scalacOptions += "-target:jvm-1.7"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.18


### PR DESCRIPTION
Fix the current build fail due to Oracle JDK license change. And other improvements: 

* Test 2.11 and 2.12 both Scala version
* Cache sbt and libraries at Travis CI
* Bump Scala version

The build will continue to fail because of test coverage. The current coverage configuration is 90%. The actual number is 75.43%. I think this number is good enough.

I think we could adjust test coverage to 75% or 80%. Later, I will see where we can improve the test coverage. 